### PR TITLE
Upgrade periphery to 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105c443a613f29212755fb6c5f946fa82dcf94a80528f643e0faa9d9faeb626b"
+checksum = "fb45cc9d1ce72e5eda341126de495a2c3810108c2333c6f3b4e09d99605f3f48"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdae15851aa41972e9c18c987613c50a916c48c88c97ea3316156a5c772e5faa"
+checksum = "16406bd1c27ff4ebdca4f5d5b09b7952f4d161f25094243e09355797c6bddaa6"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6356865217881d0bbea8aa70625937bec6d9952610f1ba2a2452a8e427000687"
+checksum = "d347ce462ceba4473d216bab2c9d0d9702a027d25e93b5376d8d8593d9e13de0"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe998ce4e6e0cb0e291d1a1626bd30791cdfdd9d05523111bdf4fd053f08636"
+checksum = "354582d796f8309252d18f787f0e49df8ab6fdfe48f838f059f001ee2f04b5c8"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5810498a20554c20354f5648b6041172f2035e58d09ad40dc051dc0d1501f80"
+checksum = "1a2e218dd8a446993463e38c00159349ae25aa76076191cde0ba460c9c65a180"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-interface"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac83f085b2be8b3a3412989cf96cf7f683561db7d357c5aa4aa11d48bbb22213"
+checksum = "1e1e536e15b13e3168cf878a90b1bd2dfff1b4c8c9475be4b87f71b20cf8e85d"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c56be575d89abcb192afa29deb87b2cdb3c39033abc02f2d16e6af999b23b7"
+checksum = "6519b3ac626c1bd9df407fe22ec6a283f4b1067ee7f3be896ca580be510b7196"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-state"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ab002353b01fcb4f72cca256d5d62db39f9ff39b1d072280deee9798f1f524"
+checksum = "88e6a21070bcb053f092a1a9054924e8a1b5afd68f7317d0138327401ac154e1"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e653cdb322078d95221384c4a527a403560e509ac7cb2b53d3bd664b23c4d6"
+checksum = "09a65890c2132f30a3ff160fb83f74e0a0454f904f46f1c9be38d3e94c2d06ed"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4815ad6334fd2f561f7ddcc3cfbeed87ed3003724171bd80ebe6383d5173ee8f"
+checksum = "ef066f4bc0cb4080ff6244b6a66ef31b6077e0302738b365ca894540f5b7dcf8"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea94b04fc9a0aaae4d4473b0595fb5f55b6c9b38e0d6f596df8c8060f95f096"
+checksum = "bcdf03d76450451f6c587098fa0d9775dc7eabf9173c89bd1bb17dd72b49e748"
 dependencies = [
  "anchor-lang",
  "solana-program",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "0.20.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be7bfb6991d79cce3495fb6ce0892f58a5c75a74c8d1c2fc6f62926066eb9f4"
+checksum = "506cb44e4e895f917566c7a0554e487a001041d82dd3ae9f1f37ae7f20f86222"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
@@ -1365,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "stable-swap-anchor"
-version = "1.6.8"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc17dafa526ed8c9443cb33206bca24013ac2f0cb7e4fb405b3a90cdc83b02ff"
+checksum = "16cfdba890aecc487da5ee84d17f55fecca4e3cb3efbb3edd50c50dd232c1544"
 dependencies = [
  "anchor-lang",
  "stable-swap-client",
@@ -1494,13 +1494,12 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vipers"
-version = "1.5.9"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8c839e2a15777b45909d05ab3eeaaa3035b43241b404345c9cd999ed30df09"
+checksum = "c7fa532cf7883844a9ca02b4b3baf96efd02926f32ec67dc22b2fb3c2349b3dc"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
- "spl-associated-token-account",
 ]
 
 [[package]]

--- a/programs/add-decimals/Cargo.toml
+++ b/programs/add-decimals/Cargo.toml
@@ -20,9 +20,9 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = ">=0.17"
-anchor-spl = ">=0.17"
-vipers = "1.5.5"
+anchor-lang = ">=0.22.1"
+anchor-spl = ">=0.22.1"
+vipers = "2.0.1"
 continuation-router = { path = "../continuation-router", version = "^1.0", features = [
     "cpi"
 ] }

--- a/programs/add-decimals/src/transfer.rs
+++ b/programs/add-decimals/src/transfer.rs
@@ -43,7 +43,7 @@ macro_rules! perform_as_wrapper {
 /// Helper methods for interacting with the user stake.
 impl<'info> UserStake<'info> {
     /// Transfer user's tokens to wrapper.
-    pub fn deposit_underlying(&self, amount: u64) -> ProgramResult {
+    pub fn deposit_underlying(&self, amount: u64) -> Result<()> {
         let cpi_accounts = token::Transfer {
             from: self.user_underlying_tokens.to_account_info(),
             to: self.wrapper_underlying_tokens.to_account_info(),
@@ -53,7 +53,7 @@ impl<'info> UserStake<'info> {
     }
 
     /// Burn user's wrapper tokens.
-    pub fn burn_wrapped(&self, amount: u64) -> ProgramResult {
+    pub fn burn_wrapped(&self, amount: u64) -> Result<()> {
         let cpi_accounts = token::Burn {
             mint: self.wrapper_mint.to_account_info(),
             to: self.user_wrapped_tokens.to_account_info(),
@@ -63,7 +63,7 @@ impl<'info> UserStake<'info> {
     }
 
     /// Mint wrapped tokens to user wrapped token account.
-    pub fn mint_wrapped(&self, amount: u64) -> ProgramResult {
+    pub fn mint_wrapped(&self, amount: u64) -> Result<()> {
         let cpi_accounts = token::MintTo {
             mint: self.wrapper_mint.to_account_info(),
             to: self.user_wrapped_tokens.to_account_info(),
@@ -73,7 +73,7 @@ impl<'info> UserStake<'info> {
     }
 
     /// Transfer underlying tokens from wrapper to user.
-    pub fn withdraw_underlying(&self, amount: u64) -> ProgramResult {
+    pub fn withdraw_underlying(&self, amount: u64) -> Result<()> {
         let cpi_accounts = token::Transfer {
             from: self.wrapper_underlying_tokens.to_account_info(),
             to: self.user_underlying_tokens.to_account_info(),

--- a/programs/continuation-router/Cargo.toml
+++ b/programs/continuation-router/Cargo.toml
@@ -20,10 +20,10 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = ">=0.17"
-anchor-spl = ">=0.17"
+anchor-lang = ">=0.22.1"
+anchor-spl = ">=0.22.1"
 spl-token = { version = "3.1.1", features = ["no-entrypoint"] }
 continuation-router-syn = { version = "^1.0", path = "./syn" }
 num_enum = "0.5.6"
-stable-swap-anchor = "1.5.4"
-vipers = "1.5.5"
+stable-swap-anchor = "1.7.3"
+vipers = "2.0.1"

--- a/programs/continuation-router/src/action/mod.rs
+++ b/programs/continuation-router/src/action/mod.rs
@@ -11,7 +11,7 @@ pub trait ProcessAction<'info>: Sized {
         ctx: &ActionContext<'_, '_, '_, 'info, Self>,
         amount_in: u64,
         minimum_amount_out: u64,
-    ) -> ProgramResult;
+    ) -> Result<()>;
 
     fn input_account(&self) -> &Account<'info, TokenAccount>;
 

--- a/programs/continuation-router/src/action/stable_swap.rs
+++ b/programs/continuation-router/src/action/stable_swap.rs
@@ -36,7 +36,7 @@ impl<'info> ProcessAction<'info> for SSDepositA<'info> {
         ctx: &ActionContext<'_, '_, '_, 'info, Self>,
         amount_in: u64,
         minimum_amount_out: u64,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         let deposit = ctx.action;
         let cpi_accounts = stable_swap_anchor::Deposit {
             user: build_swap_context!(deposit, ctx),
@@ -64,7 +64,7 @@ impl<'info> ProcessAction<'info> for SSDepositB<'info> {
         ctx: &ActionContext<'_, '_, '_, 'info, Self>,
         amount_in: u64,
         minimum_amount_out: u64,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         let deposit = ctx.action;
         let cpi_accounts = stable_swap_anchor::Deposit {
             user: build_swap_context!(deposit, ctx),
@@ -92,7 +92,7 @@ impl<'info> ProcessAction<'info> for SSWithdrawOne<'info> {
         ctx: &ActionContext<'_, '_, '_, 'info, Self>,
         amount_in: u64,
         minimum_amount_out: u64,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         let action = ctx.action;
         let cpi_accounts = stable_swap_anchor::WithdrawOne {
             user: build_swap_context!(action, ctx),
@@ -120,7 +120,7 @@ impl<'info> ProcessAction<'info> for SSSwap<'info> {
         ctx: &ActionContext<'_, '_, '_, 'info, Self>,
         amount_in: u64,
         minimum_amount_out: u64,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         let action = ctx.action;
         let cpi_accounts = stable_swap_anchor::Swap {
             user: build_swap_context!(action, ctx),

--- a/programs/continuation-router/src/lib.rs
+++ b/programs/continuation-router/src/lib.rs
@@ -41,7 +41,7 @@ pub mod continuation_router {
     use super::*;
 
     /// Creates an ATA if it does not yet exist.
-    pub fn create_ata_if_not_exists(ctx: Context<CreateATAIfNotExists>) -> ProgramResult {
+    pub fn create_ata_if_not_exists(ctx: Context<CreateATAIfNotExists>) -> Result<()> {
         if !ctx.accounts.ata.try_borrow_data()?.is_empty() {
             // ata already exists.
             return Ok(());
@@ -67,7 +67,7 @@ pub mod continuation_router {
         amount_in: u64,
         minimum_amount_out: u64,
         num_steps: u16,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         let continuation = &mut ctx.accounts.continuation;
         continuation.owner = *ctx.accounts.owner.key;
         continuation.payer = *ctx.accounts.payer.key;
@@ -102,7 +102,7 @@ pub mod continuation_router {
         amount_in: u64,
         minimum_amount_out: u64,
         num_steps: u16,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         let continuation = &mut ctx.accounts.continuation;
         continuation.owner = ctx.accounts.owner.key();
         continuation.payer = ctx.accounts.owner.key();
@@ -120,7 +120,7 @@ pub mod continuation_router {
     }
 
     /// Cleans up the transaction and checks several invariants.
-    pub fn end(ctx: Context<End>) -> ProgramResult {
+    pub fn end(ctx: Context<End>) -> Result<()> {
         let continuation = &ctx.accounts.continuation;
         require!(continuation.steps_left == 0, EndIncomplete);
 
@@ -153,37 +153,37 @@ pub mod continuation_router {
         Ok(())
     }
 
-    pub fn ss_swap<'info>(ctx: Context<'_, '_, '_, 'info, SSSwapAccounts<'info>>) -> ProgramResult {
+    pub fn ss_swap<'info>(ctx: Context<'_, '_, '_, 'info, SSSwapAccounts<'info>>) -> Result<()> {
         process_action!(ctx)
     }
 
     pub fn ss_withdraw_one<'info>(
         ctx: Context<'_, '_, '_, 'info, SSWithdrawOneAccounts<'info>>,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         process_action!(ctx)
     }
 
     pub fn ss_deposit_a<'info>(
         ctx: Context<'_, '_, '_, 'info, SSDepositAAccounts<'info>>,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         process_action!(ctx)
     }
 
     pub fn ss_deposit_b<'info>(
         ctx: Context<'_, '_, '_, 'info, SSDepositBAccounts<'info>>,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         process_action!(ctx)
     }
 
     pub fn ad_withdraw<'info>(
         ctx: Context<'_, '_, '_, 'info, ADWithdrawAccounts<'info>>,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         process_action!(ctx)
     }
 
     pub fn ad_deposit<'info>(
         ctx: Context<'_, '_, '_, 'info, ADDepositAccounts<'info>>,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         process_action!(ctx)
     }
 }
@@ -292,15 +292,7 @@ pub struct Begin<'info> {
             owner.key().as_ref(),
             random.key().as_ref()
         ],
-        bump = Pubkey::find_program_address(
-            &[
-                b"anchor".as_ref(),
-                owner.key().as_ref(),
-                random.key().as_ref(),
-            ],
-            &crate::ID,
-        )
-        .1,
+        bump,
         payer = payer
     )]
     pub continuation: Box<Account<'info, Continuation>>,
@@ -333,7 +325,6 @@ pub struct Begin<'info> {
 
 /// Begins a route.
 #[derive(Accounts)]
-#[instruction(bump: u8)]
 pub struct BeginV2<'info> {
     /// Continuation state.
     #[account(zero)]
@@ -523,7 +514,7 @@ pub struct Continuation {
 /// --------------------------------
 /// Error codes
 /// --------------------------------
-#[error]
+#[error_code]
 pub enum ErrorCode {
     #[msg("Path input does not match prior output.")]
     PathInputOutputMismatch,
@@ -602,7 +593,7 @@ pub trait RouterActionProcessor<'info, T: Accounts<'info>> {
         action: u16,
         amount_in: u64,
         minimum_amount_out: u64,
-    ) -> ProgramResult;
+    ) -> Result<()>;
 }
 
 /// Represents a swap from one token to another.

--- a/programs/continuation-router/src/processor.rs
+++ b/programs/continuation-router/src/processor.rs
@@ -27,15 +27,15 @@ pub struct ActionContext<'a, 'b, 'c, 'info, T> {
 
 /// Processes a context.
 pub trait Processor<'info>: ActionInputOutput<'info> {
-    fn process_unchecked(&self, amount_in: u64, minimum_amount_out: u64) -> ProgramResult;
+    fn process_unchecked(&self, amount_in: u64, minimum_amount_out: u64) -> Result<()>;
 
-    fn process(&self, continuation: &mut Account<'info, Continuation>) -> ProgramResult {
+    fn process(&self, continuation: &mut Account<'info, Continuation>) -> Result<()> {
         msg!("Router action: {:?}", Self::TYPE);
         let continuation = continuation;
         invariant!(continuation.steps_left > 0, NoMoreSteps);
 
         let input_account = self.input_account();
-        assert_keys_eq!(input_account, continuation.input, PathInputOutputMismatch);
+        assert_keys_eq!(input_account.key(), continuation.input, PathInputOutputMismatch);
         assert_keys_eq!(input_account.owner, continuation.owner, InputOwnerMismatch);
         assert_keys_eq!(
             input_account.mint,

--- a/programs/continuation-router/syn/src/lib.rs
+++ b/programs/continuation-router/syn/src/lib.rs
@@ -37,7 +37,7 @@ pub fn router_action(args: TokenStream, input: TokenStream) -> TokenStream {
                                 &self,
                                 amount_in: u64,
                                 minimum_amount_out: u64
-                            ) -> ProgramResult {
+                            ) -> Result<()> {
                                 crate::router_action_processor::process_action(
                                     CpiContext::new(
                                         self.swap_program.clone(),
@@ -66,7 +66,7 @@ pub fn router_action(args: TokenStream, input: TokenStream) -> TokenStream {
                             &self,
                             amount_in: u64,
                             minimum_amount_out: u64
-                        ) -> ProgramResult {
+                        ) -> Result<()> {
                             ProcessAction::process(self, amount_in, minimum_amount_out)
                         }
                     }

--- a/programs/lockup/Cargo.toml
+++ b/programs/lockup/Cargo.toml
@@ -18,8 +18,8 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = ">=0.17"
-anchor-spl = ">=0.17"
+anchor-lang = ">=0.22.1"
+anchor-spl = ">=0.22.1"
 mint-proxy = { path = "../mint-proxy", version = "^1.0", features = ["cpi"] }
 num-traits = "0.2"
-vipers = "1.5.5"
+vipers = "2.0.1"

--- a/programs/mint-proxy/Cargo.toml
+++ b/programs/mint-proxy/Cargo.toml
@@ -20,9 +20,9 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = ">=0.17"
-anchor-spl = ">=0.17"
+anchor-lang = ">=0.22.1"
+anchor-spl = ">=0.22.1"
 bytemuck = "1.4.0"
-vipers = "1.5.5"
+vipers = "2.0.1"
 spl-token = { version = "3.1.1", features = ["no-entrypoint"] }
 static-pubkey = "1.0.2"

--- a/programs/redeemer/Cargo.toml
+++ b/programs/redeemer/Cargo.toml
@@ -20,7 +20,7 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = ">=0.17"
-anchor-spl = ">=0.17"
+anchor-lang = ">=0.22.1"
+anchor-spl = ">=0.22.1"
 mint-proxy = { path = "../mint-proxy", version = "^1.0", features = ["cpi"] }
-vipers = "1.5.5"
+vipers = "2.0.1"

--- a/programs/redeemer/src/account_validators.rs
+++ b/programs/redeemer/src/account_validators.rs
@@ -4,7 +4,7 @@ use vipers::validate::Validate;
 use vipers::{assert_keys_eq, invariant};
 
 impl<'info> Validate<'info> for CreateRedeemer<'info> {
-    fn validate(&self) -> ProgramResult {
+    fn validate(&self) -> Result<()> {
         self.tokens.validate()?;
 
         assert_keys_eq!(self.tokens.redemption_vault.owner, self.redeemer);
@@ -20,7 +20,7 @@ impl<'info> Validate<'info> for CreateRedeemer<'info> {
 }
 
 impl<'info> Validate<'info> for RedeemTokens<'info> {
-    fn validate(&self) -> ProgramResult {
+    fn validate(&self) -> Result<()> {
         self.tokens.validate()?;
         self.tokens.validate_token_accounts(&self.redeemer)?;
 
@@ -42,7 +42,7 @@ impl<'info> Validate<'info> for RedeemTokens<'info> {
 }
 
 impl<'info> Validate<'info> for RedeemTokensFromMintProxy<'info> {
-    fn validate(&self) -> ProgramResult {
+    fn validate(&self) -> Result<()> {
         self.redeem_ctx.validate()?;
 
         assert_keys_eq!(
@@ -56,7 +56,7 @@ impl<'info> Validate<'info> for RedeemTokensFromMintProxy<'info> {
             "redemption_mint"
         );
 
-        assert_keys_eq!(self.mint_proxy_program, mint_proxy::ID);
+        assert_keys_eq!(self.mint_proxy_program.key(), mint_proxy::ID);
         assert_keys_eq!(
             self.proxy_mint_authority,
             self.mint_proxy_state.proxy_mint_authority,
@@ -68,7 +68,7 @@ impl<'info> Validate<'info> for RedeemTokensFromMintProxy<'info> {
 }
 
 impl<'info> Validate<'info> for ReadonlyTokenPair<'info> {
-    fn validate(&self) -> ProgramResult {
+    fn validate(&self) -> Result<()> {
         require!(
             self.iou_mint.decimals == self.redemption_mint.decimals,
             DecimalsMismatch
@@ -80,7 +80,7 @@ impl<'info> Validate<'info> for ReadonlyTokenPair<'info> {
 }
 
 impl<'info> Validate<'info> for MutTokenPair<'info> {
-    fn validate(&self) -> ProgramResult {
+    fn validate(&self) -> Result<()> {
         assert_keys_eq!(self.redemption_vault.mint, self.redemption_mint);
 
         Ok(())

--- a/programs/redeemer/src/mut_token_pair.rs
+++ b/programs/redeemer/src/mut_token_pair.rs
@@ -11,7 +11,7 @@ impl<'info> MutTokenPair<'info> {
         source_account: AccountInfo<'info>,
         source_authority: AccountInfo<'info>,
         amount: u64,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         let cpi_accounts = token::Burn {
             mint: self.iou_mint.to_account_info(),
             to: source_account,
@@ -23,7 +23,7 @@ impl<'info> MutTokenPair<'info> {
         Ok(())
     }
 
-    pub fn validate_token_accounts(&self, redeemer: &Account<Redeemer>) -> ProgramResult {
+    pub fn validate_token_accounts(&self, redeemer: &Account<Redeemer>) -> Result<()> {
         assert_keys_eq!(self.iou_mint, redeemer.iou_mint, "iou_mint");
         assert_keys_eq!(
             self.redemption_mint,


### PR DESCRIPTION
Problem:

Jupiter uses the cpi features of the add-decimals crate, but anchor isn't compatible.
A few errors on build, for instance:
```
error: cannot find attribute `error` in this scope
  --> $HOME/.cargo/registry/src/github.com-1ecc6299db9ec823/vipers-1.5.7/src/lib.rs:30:3
   |
30 | #[error(offset = 1100)]
   |   ^^^^^
   |
```

There are some oddities around bump being canonical by default and them being accessible in the methods through bumps vs the old argument: Should the old argument be verified or just ignored?

I need to check why vipers wants this weird trait implementation for `unwrap_or_err`

Let me know if i should continue on this and your thoughts